### PR TITLE
Support using Trailblazer in teleop

### DIFF
--- a/src/main/java/frc/robot/autos/Trailblazer.java
+++ b/src/main/java/frc/robot/autos/Trailblazer.java
@@ -62,6 +62,7 @@ public class Trailblazer {
             .alongWith(
                 Commands.run(
                     () -> {
+                      swerve.startTrailblazerRequest();
                       pathTracker.updateRobotState(
                           localization.getPose(), swerve.getFieldRelativeSpeeds());
                       var currentAutoPointIndex = pathTracker.getCurrentPointIndex();

--- a/src/main/java/frc/robot/autos/Trailblazer.java
+++ b/src/main/java/frc/robot/autos/Trailblazer.java
@@ -89,6 +89,7 @@ public class Trailblazer {
                       }
                     },
                     swerve))
+            .finallyDo(swerve::finishTrailblazerRequest)
             .withName("FollowSegmentIndefinitely");
 
     if (shouldEnd) {

--- a/src/main/java/frc/robot/swerve/SwerveState.java
+++ b/src/main/java/frc/robot/swerve/SwerveState.java
@@ -3,6 +3,7 @@ package frc.robot.swerve;
 public enum SwerveState {
   TELEOP,
   TELEOP_SNAPS,
+  TELEOP_TRAILBLAZER,
   AUTO,
   AUTO_SNAPS,
   REEF_ALIGN_TELEOP,

--- a/src/main/java/frc/robot/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/swerve/SwerveSubsystem.java
@@ -173,15 +173,14 @@ public class SwerveSubsystem extends StateMachine<SwerveState> {
       case AUTO, TELEOP -> DriverStation.isAutonomous() ? SwerveState.AUTO : SwerveState.TELEOP;
       case INTAKE_ASSIST_ALGAE_TELEOP, INTAKE_ASSIST_CORAL_TELEOP ->
           DriverStation.isAutonomous() ? SwerveState.AUTO : currentState;
-      case REEF_ALIGN_TELEOP ->
-          DriverStation.isAutonomous() ? SwerveState.AUTO : SwerveState.REEF_ALIGN_TELEOP;
       case REEF_ALIGN_TELEOP_FINE_ADJUST ->
           DriverStation.isAutonomous()
               ? SwerveState.AUTO
               : SwerveState.REEF_ALIGN_TELEOP_FINE_ADJUST;
       case AUTO_SNAPS, TELEOP_SNAPS ->
           DriverStation.isAutonomous() ? SwerveState.AUTO_SNAPS : SwerveState.TELEOP_SNAPS;
-      case CLIMBING -> DriverStation.isAutonomous() ? SwerveState.AUTO : SwerveState.CLIMBING;
+      case CLIMBING, TELEOP_TRAILBLAZER, REEF_ALIGN_TELEOP ->
+          DriverStation.isAutonomous() ? SwerveState.AUTO : currentState;
     };
   }
 
@@ -329,7 +328,7 @@ public class SwerveSubsystem extends StateMachine<SwerveState> {
                   .withDriveRequestType(DriveRequestType.OpenLoopVoltage));
         }
       }
-      case AUTO ->
+      case AUTO, TELEOP_TRAILBLAZER ->
           drivetrain.setControl(
               drive
                   .withVelocityX(autoSpeeds.vxMetersPerSecond)
@@ -469,5 +468,11 @@ public class SwerveSubsystem extends StateMachine<SwerveState> {
 
   public void setElevatorHeight(double height) {
     elevatorHeight = height;
+  }
+
+  public void finishTrailblazerRequest() {
+    if (getState() == SwerveState.TELEOP_TRAILBLAZER) {
+      setStateFromRequest(SwerveState.TELEOP);
+    }
   }
 }

--- a/src/main/java/frc/robot/swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/swerve/SwerveSubsystem.java
@@ -475,4 +475,12 @@ public class SwerveSubsystem extends StateMachine<SwerveState> {
       setStateFromRequest(SwerveState.TELEOP);
     }
   }
+
+  public void startTrailblazerRequest() {
+    if (DriverStation.isAutonomous()) {
+      setStateFromRequest(SwerveState.AUTO);
+    } else {
+      setStateFromRequest(SwerveState.TELEOP_TRAILBLAZER);
+    }
+  }
 }


### PR DESCRIPTION
TODO: Need to figure out how to not constantly go back into `TELEOP` swerve state when the `normalDriveRequest()` gets triggered from robot state transitions. I guess maybe that's not an issue since Trailblazer is calling `swerve.startTrailblazerRequest()` continuously?