### PR TITLE
Support customizing tolerance for AutoSegment position

### DIFF
--- a/src/main/java/frc/robot/autos/AutoBlocks.java
+++ b/src/main/java/frc/robot/autos/AutoBlocks.java
@@ -10,8 +10,16 @@ import frc.robot.auto_align.ReefPipeLevel;
 import frc.robot.autos.constraints.AutoConstraintOptions;
 import frc.robot.elevator.CoralStation;
 import frc.robot.robot_manager.RobotManager;
+import frc.robot.util.PoseErrorTolerance;
 
 public class AutoBlocks {
+  /**
+   * The tolerance used to determine when to end the little "backup & stow" motion we do after
+   * scoring L4.
+   */
+  private static final PoseErrorTolerance AFTER_SCORE_POSITION_TOLERANCE =
+      new PoseErrorTolerance(0.2, 10);
+
   /**
    * The offset used to calculate the position to go to before PIDing to the lineup pose. Ensures we
    * don't strafe into the scoring position, just a straight-on movement.
@@ -76,6 +84,7 @@ public class AutoBlocks {
         trailblazer.followSegment(
             new AutoSegment(
                 BASE_CONSTRAINTS,
+                AFTER_SCORE_POSITION_TOLERANCE,
                 new AutoPoint(
                     () -> robotManager.autoAlign.getUsedScoringPose(pipe, ReefPipeLevel.L4),
                     Commands.waitSeconds(0.15).andThen(robotManager::stowRequest)),
@@ -131,6 +140,7 @@ public class AutoBlocks {
         trailblazer.followSegment(
             new AutoSegment(
                 BASE_CONSTRAINTS,
+                AFTER_SCORE_POSITION_TOLERANCE,
                 // Start at the scoring position
                 new AutoPoint(
                     () -> robotManager.autoAlign.getUsedScoringPose(pipe, ReefPipeLevel.L4),

--- a/src/main/java/frc/robot/autos/Trailblazer.java
+++ b/src/main/java/frc/robot/autos/Trailblazer.java
@@ -97,7 +97,8 @@ public class Trailblazer {
 
     if (shouldEnd) {
       return command
-          .until(pathTracker::isFinished)
+          .until(
+              () -> segment.isFinished(localization.getPose(), pathTracker.getCurrentPointIndex()))
           .andThen(
               Commands.runOnce(
                   () -> {

--- a/src/main/java/frc/robot/autos/trackers/HeuristicPathTracker.java
+++ b/src/main/java/frc/robot/autos/trackers/HeuristicPathTracker.java
@@ -24,9 +24,6 @@ public class HeuristicPathTracker implements PathTracker {
 
   @Override
   public Pose2d getTargetPose() {
-    if (isFinished() == true) {
-      return null;
-    }
     AutoPoint currentPoint = points.get(getCurrentPointIndex());
     Pose2d currentTargetPose = currentPoint.poseSupplier.get();
 
@@ -52,10 +49,5 @@ public class HeuristicPathTracker implements PathTracker {
   @Override
   public int getCurrentPointIndex() {
     return currentPointIndex;
-  }
-
-  @Override
-  public boolean isFinished() {
-    return false;
   }
 }

--- a/src/main/java/frc/robot/autos/trackers/PathTracker.java
+++ b/src/main/java/frc/robot/autos/trackers/PathTracker.java
@@ -40,11 +40,4 @@ public interface PathTracker {
    * @return The index point being tracked.
    */
   public int getCurrentPointIndex();
-
-  /**
-   * Check whether the robot has finished following all the points.
-   *
-   * @return Whether the robot has finished following all the points.
-   */
-  public boolean isFinished();
 }

--- a/src/main/java/frc/robot/autos/trackers/pure_pursuit/PurePursuitPathTracker.java
+++ b/src/main/java/frc/robot/autos/trackers/pure_pursuit/PurePursuitPathTracker.java
@@ -1,6 +1,5 @@
 package frc.robot.autos.trackers.pure_pursuit;
 
-import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
@@ -160,24 +159,6 @@ public class PurePursuitPathTracker implements PathTracker {
   @Override
   public int getCurrentPointIndex() {
     return currentRobotFollowedPointIndex;
-  }
-
-  @Override
-  public boolean isFinished() {
-    if (points.isEmpty()) {
-      return true;
-    }
-    if ((currentRobotPose
-                .getTranslation()
-                .getDistance(points.get(points.size() - 1).poseSupplier.get().getTranslation())
-            < AT_END_OF_SEGMENT_DISTANCE_THRESHOLD)
-        && MathUtil.isNear(
-            points.get(points.size() - 1).poseSupplier.get().getRotation().getDegrees(),
-            currentRobotPose.getRotation().getDegrees(),
-            AT_END_OF_SEGMENT_ROTATION_THRESHOLD)) {
-      return true;
-    }
-    return false;
   }
 
   private void updateLookahead() {

--- a/src/main/java/frc/robot/util/PoseErrorTolerance.java
+++ b/src/main/java/frc/robot/util/PoseErrorTolerance.java
@@ -1,0 +1,26 @@
+package frc.robot.util;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+
+public record PoseErrorTolerance(double linearErrorTolerance, double angularErrorTolerance) {
+  public PoseErrorTolerance(double linearErrorTolerance, Rotation2d angularErrorTolerance) {
+    this(linearErrorTolerance, angularErrorTolerance.getDegrees());
+  }
+
+  public boolean atPose(Pose2d expected, Pose2d actual) {
+    var linearError = expected.getTranslation().getDistance(actual.getTranslation());
+
+    // Linear error within tolerance
+    return MathUtil.isNear(0, linearError, linearErrorTolerance)
+        &&
+        // Rotation error within tolerance
+        MathUtil.isNear(
+            expected.getRotation().getDegrees(),
+            actual.getRotation().getDegrees(),
+            angularErrorTolerance,
+            -180,
+            180);
+  }
+}


### PR DESCRIPTION
The thinking here is that sometimes we don't care much about being precise. For example, if we've already scored and are just backing up, it's not a big deal if we're a few inches off from the theoretical perfect position after backing up.

We spend a bunch of time doing that in auto, this PR makes it so that:
- Each `AutoSegment` can have customizable position tolerance (defaults to the numbers we've been using previously)
- `AutoBlocks` scoring commands have a broader tolerance (0.2m linear, 10° angular) for the 'backup and stow' portion of the score command